### PR TITLE
Update php-cs-fixer repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpmd/phpmd": "~2.0",
         "squizlabs/php_codesniffer": "~2.0",
 
-        "fabpot/php-cs-fixer": "~1.0",
+        "friendsofphp/php-cs-fixer": "~1.12",
         "sensiolabs/security-checker": "~3.0",
 
         "behat/behat": "~3.0"


### PR DESCRIPTION
Fixes warning `Package fabpot/php-cs-fixer is abandoned, you should avoid using it. Use friendsofphp/php-cs-fixer instead.`
